### PR TITLE
GitHub Codespaces support || release `1.2.0`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.233.0/containers/javascript-node/.devcontainer/base.Dockerfile
+
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
+ARG VARIANT="18-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node modules
+# RUN su node -c "npm install -g <your-package-list-here>"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,16 +1,4 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.233.0/containers/javascript-node/.devcontainer/base.Dockerfile
 
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
-ARG VARIANT="18-bullseye"
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
-
-# [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
-
-# [Optional] Uncomment if you want to install an additional version of node using nvm
-# ARG EXTRA_NODE_VERSION=10
-# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
-
-# [Optional] Uncomment if you want to install more global node modules
-# RUN su node -c "npm install -g <your-package-list-here>"
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-16-bullseye

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,10 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"dbaeumer.vscode-eslint"
+		"matklad.rust-analyzer",
+    "bungcip.better-toml",
+    "serayuzgur.crates",
+    "EditorConfig.EditorConfig"
 	],
 
 	// Use 'postCreateCommand' to run commands after the container is created.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.233.0/containers/javascript-node
+{
+	"name": "Node.js",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick a Node version: 18, 16, 14.
+		// Append -bullseye or -buster to pin to an OS version.
+		// Use -bullseye variants on local arm64/Apple Silicon.
+		"args": { "VARIANT": "16-bullseye" }
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "yarn install",
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node",
+	"features": {
+		"rust": "latest"
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "yarn install",
+	"postCreateCommand": "cargo install wasm-pack",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,25 +1,15 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.233.0/containers/javascript-node
 {
-	"name": "Node.js",
+	"name": "nextjs-wasm",
 	"build": {
-		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick a Node version: 18, 16, 14.
-		// Append -bullseye or -buster to pin to an OS version.
-		// Use -bullseye variants on local arm64/Apple Silicon.
-		"args": { "VARIANT": "16-bullseye" }
+		"dockerfile": "Dockerfile"
 	},
-
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"dbaeumer.vscode-eslint"
 	],
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "cargo install wasm-pack",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,25 +1,25 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.233.0/containers/javascript-node
 {
-	"name": "nextjs-wasm",
-	"build": {
-		"dockerfile": "Dockerfile"
+  "name": "nextjs-wasm",
+  "build": {
+    "dockerfile": "Dockerfile"
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"matklad.rust-analyzer",
+    "matklad.rust-analyzer",
     "bungcip.better-toml",
     "serayuzgur.crates",
     "EditorConfig.EditorConfig"
 	],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "cargo install wasm-pack",
+  "postCreateCommand": "cargo install wasm-pack",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "node",
-	"features": {
-		"rust": "latest"
-	}
+  "remoteUser": "node",
+  "features": {
+    "rust": "latest"
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-    "matklad.rust-analyzer",
+    "rust-lang.rust-analyzer",
     "bungcip.better-toml",
     "serayuzgur.crates",
     "EditorConfig.EditorConfig"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,20 +4,20 @@
   "name": "nextjs-wasm",
   "build": {
     "dockerfile": "Dockerfile"
-	},
+  },
 
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
     "rust-lang.rust-analyzer",
     "bungcip.better-toml",
     "serayuzgur.crates",
     "EditorConfig.EditorConfig"
-	],
+  ],
 
-	// Use 'postCreateCommand' to run commands after the container is created.
+  // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": "cargo install wasm-pack",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "node",
   "features": {
     "rust": "latest"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,7 +8,7 @@ tasks:
       npm run dev
 vscode:
   extensions:
-    - matklad.rust-analyzer
+    - rust-lang.rust-analyzer
     - bungcip.better-toml
     - serayuzgur.crates
     - EditorConfig.EditorConfig

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-# NextJS WASM
+# Next.js with WebAssembly
+
+## Try in [Gitpod](https://www.gitpod.io/)
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/satelllte/nextjs-wasm)
+
+## Try in [GitHub Codespaces](https://github.com/features/codespaces)
+
+[![Open in Remote - Containers](https://img.shields.io/static/v1?label=Remote%20-%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/satelllte/nextjs-wasm)
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Next.js with WebAssembly
 
+[Next.js](https://nextjs.org/)-based web application template with [WebAssembly](https://webassembly.org/) module written in [Rust](https://www.rust-lang.org/) programming language.
+
 ## Try in [Gitpod](https://www.gitpod.io/)
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/satelllte/nextjs-wasm)

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ## Prerequisites
 
-- [NodeJS](https://nodejs.org/) | recommended version: 16
-- [Rust & Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html) | recommended version: 1.61
-- [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) | recommended version: 0.10.2
+- [NodeJS](https://nodejs.org/) | recommended version: `16`
+- [Rust & Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html) | recommended version: `1.61`
+- [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) | recommended version: `0.10.2`
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ## Prerequisites
 
-- [NodeJS](https://nodejs.org/)
-- [Rust & Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html)
-- [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/)
+- [NodeJS](https://nodejs.org/) | recommended version: 16
+- [Rust & Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html) | recommended version: 1.61
+- [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) | recommended version: 0.10.2
 
 ## Getting Started
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextjs-wasm",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nextjs-wasm",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "dependencies": {
         "next": "12.1.6",
         "react": "18.1.0",
@@ -3202,7 +3202,7 @@
     },
     "wasm/pkg": {
       "name": "wasm",
-      "version": "1.0.0"
+      "version": "1.2.0"
     }
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-wasm",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "scripts": {
     "dev": "next dev",
     "build:wasm": "cd wasm && ./rs-build.sh",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
 name = "wasm"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "wasm-bindgen",
 ]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm"
-version = "1.1.1"
+version = "1.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Changes

- [x] Codespaces: NodeJS support
- [x] Codespaces: Rust support
- [x] Codespaces: button in `README.md`
- [x] Devcontainer configuration: add VSCode extensions
- [x] Other: Recommended versions of dependencies mentioned in `README.md` file
- [x] Bump template version: `1.2.0`