### PR TITLE
[FIX] `rust-analyzer` VSCode extension broken on Gitpod || release `1.2.1`

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,7 +8,7 @@ tasks:
       npm run dev
 vscode:
   extensions:
-    - rust-lang.rust-analyzer
+    - matklad.rust-analyzer
     - bungcip.better-toml
     - serayuzgur.crates
     - EditorConfig.EditorConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextjs-wasm",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nextjs-wasm",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "next": "12.1.6",
         "react": "18.1.0",
@@ -3202,7 +3202,7 @@
     },
     "wasm/pkg": {
       "name": "wasm",
-      "version": "1.2.0"
+      "version": "1.2.1"
     }
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-wasm",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "scripts": {
     "dev": "next dev",
     "build:wasm": "cd wasm && ./rs-build.sh",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
 name = "wasm"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "wasm-bindgen",
 ]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Description

Gitpod uses [Open VSX Registry](https://open-vsx.org/) for VSCode extensions, so it needs to fix the id of [rust-analyzer](https://open-vsx.org/extension/matklad/rust-analyzer) extension in `.gitpod.yml` config