### PR TITLE
Fix "memory access out of bounds" error

### DIFF
--- a/src/context/WASM.tsx
+++ b/src/context/WASM.tsx
@@ -1,6 +1,18 @@
 import { ReactNode, useEffect, useState } from 'react'
 import { createContext } from 'react'
 
+// initialize at module scope, to prevent executing twice on strict mode,
+// which can cause issues when calling async functions on wasm
+const wasmPromise = import('wasm').then(wasm => {
+  if (typeof window !== "undefined") { 
+      // client side: initialize
+      return wasm.default().then(() => wasm)
+  } else { 
+      // server side: do nothing
+      return wasm
+  }
+}) 
+
 const initial: IWASMContext = {}
 
 export const WASMContext = createContext(initial)
@@ -12,8 +24,7 @@ export const WASMContextProvider: React.FC<WASMContextProviderProps> = ({
 
   useEffect(() => {
     (async() => {
-      const wasm = await import('wasm')
-      await wasm.default()
+      const wasm = await wasmPromise
       setState({ wasm })
     })()
   }, [])


### PR DESCRIPTION
After [this discussion](https://github.com/rustwasm/wasm-bindgen/issues/3153) and some trial and error I ended with this, which seems to fix the issue. 

The check for server / client is not nice however. Maybe we should use a `useRef` flag instead, like here https://stackoverflow.com/a/72843344/930450

Fixes https://github.com/satelllte/nextjs-wasm/issues/76